### PR TITLE
Move input data file to /data

### DIFF
--- a/chatbots/transformer_chatbot/create_dataset.py
+++ b/chatbots/transformer_chatbot/create_dataset.py
@@ -18,7 +18,7 @@ MAX_SAMPLES = int(os.environ.get('MAX_SAMPLES'))
 
 datapath = './data/'
 path = f"{datapath}{EPOCHS}EPOCHS_{MAX_SAMPLES}SAMPLES_{MAX_LENGTH}LENGTH/"
-filename = 'transformer_data.csv'
+filename = f"{datapath}/input_data.csv"
 os.mkdir(path)
 
 

--- a/chatbots/transformer_chatbot/prepare_movie_dialog_data.py
+++ b/chatbots/transformer_chatbot/prepare_movie_dialog_data.py
@@ -3,7 +3,7 @@ import re
 import csv
 
 
-OUTPUT_PATH = "transformer_data.csv"
+OUTPUT_PATH = "data/input_data.csv"
 
 def extract_line_data():
     with open("data/movie_dialog_corpus/movie_lines.tsv", encoding="utf-8") as file:


### PR DESCRIPTION
Momentan erwartet `create_dataset.py`, dass die Input CSV Datei `/transformer_data.csv` heißt. Ich würde die CSV gerne in `/data/input_data.csv` umbenennen, sodass sie von Git ignoriert wird und nicht aus Versehen gepusht werden kann.

Wär das ok für euch?